### PR TITLE
Use separate StringIO objects for each upload target

### DIFF
--- a/lib/capistrano/dotenv/tasks.cap
+++ b/lib/capistrano/dotenv/tasks.cap
@@ -34,11 +34,9 @@ namespace :dotenv do
   task :setup do
     dotenv_contents = fetch(:dotenv_contents)
 
-    dotenv = StringIO.new
-    dotenv << dotenv_contents
-    dotenv.rewind
-
     on roles(fetch(:dotenv_roles, :all)) do
+      dotenv = StringIO.new(dotenv_contents)
+
       upload! dotenv, File.join(shared_path, '.env')
     end
   end


### PR DESCRIPTION
This is to avoid getting stuck in IO.select when multiple scp sessions read from
the same StringIO object.